### PR TITLE
Remove phpbb as requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "phpbb/phpbb": ">=3.2.0,<3.3.0@dev"
+        "php": ">=5.4.7"
     },
     "extra": {
         "display-name": "Knowledge Base",


### PR DESCRIPTION
To be able to install it via "composer.phar install" as a dependency of phpbb without the need of the extension to install phpbb as a dependency, too. 