### PR TITLE
Fix article head in responsive mode

### DIFF
--- a/styles/prosilver/theme/knowledgebase_controller.css
+++ b/styles/prosilver/theme/knowledgebase_controller.css
@@ -66,6 +66,10 @@ p.description {
 }
 
 /* KB responsive lists */
-/*@media only screen and (max-width: 700px), only screen and (max-device-width: 700px) {
-
-}*/
+@media (max-width: 700px) {
+	.article-body .article-meta,
+	.article-body .article-description,
+	.article-body .article-categories {
+		float: left;
+	}
+}


### PR DESCRIPTION
Without that fix, the article-description gets smaller and smaller until it is no longer readable in mobile view. 